### PR TITLE
Fix subscribe() spurious callback on first dispatch

### DIFF
--- a/src/Data/StateNode.ts
+++ b/src/Data/StateNode.ts
@@ -99,8 +99,8 @@ export class StateNode<T>
   
   public subscribe(callback: (data: T) => void): () => void
   {
-    let currentValue = this.lastKnownValue;
-    
+    let currentValue = this.get();
+
     return this.treedux.subscribe(() => {
       const newValue = this.get();
       if (JSON.stringify(newValue) === JSON.stringify(currentValue)) return;


### PR DESCRIPTION
## Problem

`StateNode.subscribe()` initialises its comparison baseline using `this.lastKnownValue`. If `get()` has never been called on the node instance, `lastKnownValue` is `undefined`. This causes the subscriber callback to fire on the first dispatch — even when the subscribed node hasn't changed — because `JSON.stringify(undefined)` doesn't match `JSON.stringify(actualValue)`.

### Reproduction

```typescript
const treedux = Treedux.init({
  test: DataStore.create('test', { initialState: { a: null, b: null } })
});

const callback = jest.fn();
treedux.state.test.a.subscribe(callback);

// Change an UNRELATED node
treedux.dispatch(treedux.state.test.b.set('hello'));

// callback fires with `null` even though `a` never changed
expect(callback).toHaveBeenCalled(); // passes, but shouldn't
```

## Fix

One-line change in `StateNode.subscribe()`:

```diff
- let currentValue = this.lastKnownValue;
+ let currentValue = this.get();
```

`this.get()` always reads the real current value from the Redux store, so the baseline is correct regardless of whether `get()` was previously called.

## Impact

This is a bug fix with no breaking changes. Subscribers will no longer receive spurious callbacks when unrelated state changes.