### PR TITLE
Cache StateNode instances by key path for stable references

### DIFF
--- a/src/Data/StateNode.ts
+++ b/src/Data/StateNode.ts
@@ -121,30 +121,36 @@ export class StateNode<T>
       get(target, property: string | symbol)
       {
         const currentValue = target.get();
-        
-        // If accessing a property of the data object, return a new StateNode
+
+        // If accessing a property of the data object, return a cached StateNode
         if (
           typeof property === 'string'
           && Objects.isObject(currentValue)
           && property in currentValue
         )
         {
-          // const value = currentValue[prop as keyof T] as T;
-          
-          return StateNode.create(
+          const childKeyPath = target.keyPath.concat(property);
+          const cacheKey = childKeyPath.join('.');
+
+          const cached = target.treedux.getCachedNode(cacheKey);
+          if (cached) return cached;
+
+          const node = StateNode.create(
             {
-              keyPath: target.keyPath.concat(property)
+              keyPath: childKeyPath
             },
             target.treedux
           );
-          
+
+          target.treedux.setCachedNode(cacheKey, node);
+          return node;
         }
         // Else if accessing a method of the StateNode, bind it to the StateNode
         else if (typeof target[property] === 'function')
         {
           return target[property].bind(target);
         }
-        
+
         // Default to returning the property (even if it doesn't exist)
         return target[property];
       },

--- a/src/Treedux.ts
+++ b/src/Treedux.ts
@@ -17,6 +17,7 @@ export class Treedux<DataStoreMap extends DefaultDataStoreMap = DefaultDataStore
 {
   private dataStores: DataStoreMap;
   private storeInstance: ToolkitStore;
+  private readonly nodeCache: Map<string, any> = new Map();
   
   protected constructor(dataStores: DataStoreMap, options?: { initialState?: any })
   {
@@ -99,6 +100,16 @@ export class Treedux<DataStoreMap extends DefaultDataStoreMap = DefaultDataStore
     return this.storeInstance.subscribe(callback);
   }
   
+  public getCachedNode(cacheKey: string): any | undefined
+  {
+    return this.nodeCache.get(cacheKey);
+  }
+
+  public setCachedNode(cacheKey: string, node: any): void
+  {
+    this.nodeCache.set(cacheKey, node);
+  }
+
   public dispatch(...actions: Array<Action>): void
   {
     if (!this.storeInstance) throw "Cannot dispatch action. Redux store has not been initialized.";


### PR DESCRIPTION
## Problem

Every property access on the state tree (e.g. `treedux.state.user.uid`) creates a **new StateNode instance** wrapped in a new Proxy:

```typescript
const node1 = treedux.state.user.uid;
const node2 = treedux.state.user.uid;
console.log(node1 === node2); // false
```

This causes several issues:

1. **Broken subscribe baseline** — calling `.get()` on one instance primes `lastKnownValue` on that instance only. A subsequent `.subscribe()` call accesses a different instance with `lastKnownValue` still `undefined`, leading to spurious callbacks (related to #3).

2. **React hook re-subscriptions** — hooks that use the node as a `useEffect` dependency re-subscribe on every render because the reference changes.

3. **useSyncExternalStore incompatibility** — requires a stable `getSnapshot` function, which is impossible when the node reference changes each access.

4. **Unnecessary allocations** — new objects and Proxies are created on every property access, adding GC pressure.

## Fix

Added a `Map<string, StateNode>` cache on the Treedux instance, keyed by the dot-joined key path (e.g. `"user.uid"`). The createProxy getter checks the cache before creating a new node. After this fix, the same key path always returns the same StateNode instance.

## Impact

Non-breaking change — the external API is identical. Node identity is now stable, which:
- Fixes the lastKnownValue issue as a side effect (same instance = shared state)
- Enables useSyncExternalStore for React integrations
- Eliminates unnecessary re-subscriptions in React hooks
- Reduces object allocations