### PR TITLE
Replace JSON.stringify with fast-deep-equal for subscribe comparison

### DIFF
--- a/src/Data/StateNode.ts
+++ b/src/Data/StateNode.ts
@@ -1,3 +1,4 @@
+import equal from "fast-deep-equal";
 import { DefaultActionEnum } from "../Enum/DefaultActionEnum";
 import { Treedux } from "../Treedux";
 import { Objects } from "../Utility/Objects";
@@ -100,10 +101,10 @@ export class StateNode<T>
   public subscribe(callback: (data: T) => void): () => void
   {
     let currentValue = this.lastKnownValue;
-    
+
     return this.treedux.subscribe(() => {
       const newValue = this.get();
-      if (JSON.stringify(newValue) === JSON.stringify(currentValue)) return;
+      if (equal(newValue, currentValue)) return;
       currentValue = newValue;
       callback(currentValue);
     })


### PR DESCRIPTION
## Problem

`StateNode.subscribe()` uses `JSON.stringify` to compare previous and new values on every store update:

```js
if (JSON.stringify(newValue) === JSON.stringify(currentValue)) return;
```

This has several issues:

**Performance:**
- Allocates two new strings on every comparison, creating GC pressure
- Cannot bail early — must serialize the entire value even if the first property differs
- For large objects/arrays, this is O(n) every time with no short-circuit

**Correctness:**
- `JSON.stringify(undefined)` returns `undefined` (not a string), breaking the comparison
- `NaN` is serialized as `null`
- `Infinity` is serialized as `null`
- Functions and Symbols are silently dropped

## Fix

Replaced `JSON.stringify` comparison with `fast-deep-equal`:

```js
if (equal(newValue, currentValue)) return;
```

`fast-deep-equal` is:
- ~1KB, zero dependencies (already a transitive dependency via `@reduxjs/toolkit`)
- Short-circuits on first difference found (O(1) best case vs O(n) always for stringify)
- Zero allocations — compares values in-place
- Correctly handles `undefined`, `NaN`, `Date`, `RegExp`, and other types

## Impact

Non-breaking change. Subscribers behave identically but with better performance, especially for branch-level subscriptions on larger objects/arrays. Also fixes edge cases around `undefined` and `NaN` comparisons.